### PR TITLE
Return null pointer in case allocation fails. 

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,7 +53,7 @@ pub unsafe extern "C" fn malloc(len: usize) -> *mut c_void {
         0,
     );
     if ptr == libc::MAP_FAILED {
-        libc::PT_NULL as *mut libc::c_void
+        ptr::null_mut()
     } else {
         // This is guaranteed to be aligned
         *(ptr as *mut usize) = full_len;
@@ -83,7 +83,7 @@ pub unsafe extern "C" fn calloc(n_items: usize, item_len: usize) -> *mut c_void 
         0,
     );
     if ptr == libc::MAP_FAILED {
-        libc::PT_NULL as *mut libc::c_void
+        ptr::null_mut()
     } else {
         // This is guaranteed to be aligned
         *(ptr as *mut usize) = full_len;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,11 +52,15 @@ pub unsafe extern "C" fn malloc(len: usize) -> *mut c_void {
         -1,
         0,
     );
-    // This is guaranteed to be aligned
-    *(ptr as *mut usize) = full_len;
-    ptr = ptr.offset(CANARY_SIZE as isize);
-    libc::memset(ptr, get_mem_init().into(), len + alloc_extra_mem);
-    ptr
+    if ptr == libc::MAP_FAILED {
+        libc::PT_NULL as *mut libc::c_void
+    } else {
+        // This is guaranteed to be aligned
+        *(ptr as *mut usize) = full_len;
+        ptr = ptr.offset(CANARY_SIZE as isize);
+        libc::memset(ptr, get_mem_init().into(), len + alloc_extra_mem);
+        ptr
+    }
 }
 
 #[no_mangle]
@@ -78,16 +82,20 @@ pub unsafe extern "C" fn calloc(n_items: usize, item_len: usize) -> *mut c_void 
         -1,
         0,
     );
-    // This is guaranteed to be aligned
-    *(ptr as *mut usize) = full_len;
-    ptr = ptr.offset(CANARY_SIZE as isize);
-    libc::memset(ptr, 0, len);
-    libc::memset(
-        ptr.offset(len as isize),
-        get_mem_init().into(),
-        alloc_extra_mem,
-    );
-    ptr
+    if ptr == libc::MAP_FAILED {
+        libc::PT_NULL as *mut libc::c_void
+    } else {
+        // This is guaranteed to be aligned
+        *(ptr as *mut usize) = full_len;
+        ptr = ptr.offset(CANARY_SIZE as isize);
+        libc::memset(ptr, 0, len);
+        libc::memset(
+            ptr.offset(len as isize),
+            get_mem_init().into(),
+            alloc_extra_mem,
+        );
+        ptr
+    }
 }
 
 #[no_mangle]


### PR DESCRIPTION
This is the behavior that POSIX prescribes and libdiffuzz-c99 [already implements](https://github.com/Shnatsel/libdiffuzz-c99/blob/master/libdiffuzz.so.c#L117)

Thanks to [InaneB0b on Reddit](https://www.reddit.com/r/rust/comments/9p8upx/libdiffuzz_the_tool_that_discovered/e81wbhw/) for pointing this out